### PR TITLE
Added Vagrantfile, to simplify reproducing this.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 pywebsocket/
 target/
 venv/
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+#
+# To boot this Vagrant machine, run: vagrant up --provider virtualbox
+#
+Vagrant.configure(2) do |config|
+  config.vm.box = 'ubuntu/trusty64'
+
+  config.vm.provision 'shell', inline: <<-SHELL
+    set -e
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y git libssl-dev
+    curl -sSf https://static.rust-lang.org/rustup.sh > /tmp/rustup.sh && \
+        sh /tmp/rustup.sh --yes --channel=stable
+    cd /vagrant && git clone https://github.com/google/pywebsocket.git
+SHELL
+end


### PR DESCRIPTION
...since I'm not running Ubuntu on my host.

---

I tried using this, started one process like this:

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ PYTHONPATH=./pywebsocket python pywebsocket/mod_pywebsocket/standalone.py -d ./handlers -p 7777 -l foo.log --log-level=debug
```

...and the other like this:

```
vagrant@vagrant-ubuntu-trusty-64:/vagrant$ cargo run
```

Nonetheless, I didn't get any output _at all_ on the Rust side of the pipe. It just seemed stalled - never shut down, from what I could tell. Did I reproduce the problem? :smile: It feels like it would be more random than this, wouldn't it?

In `handlers/foo.log`, I got something though:

```
[2016-03-26 15:32:51,206] [INFO] __main__.WebSocketServer: Create socket on: (10, 1, '', '', '')
[2016-03-26 15:32:51,206] [INFO] __main__.WebSocketServer: Create socket on: (2, 1, '', '', '')
[2016-03-26 15:32:51,207] [INFO] __main__.WebSocketServer: Bind on: (10, 1, '', '', '')
[2016-03-26 15:32:51,207] [INFO] __main__.WebSocketServer: Bind on: (2, 1, '', '', '')
[2016-03-26 15:32:51,207] [INFO] __main__.WebSocketServer: Listen on: (10, 1, '', '', '')
[2016-03-26 15:32:51,207] [INFO] __main__.WebSocketServer: Listen on: (2, 1, '', '', '')
[2016-03-26 15:32:51,207] [INFO] __main__.WebSocketServer: Skip by failure: error(98, 'Address already in use')
[2016-03-26 15:32:53,463] [DEBUG] mod_pywebsocket.handshake: Client's opening handshake resource: '/simulate_lockup'
[2016-03-26 15:32:53,463] [DEBUG] mod_pywebsocket.handshake: Client's opening handshake headers: {'host': '127.0.0.1:7777', 'upgrade': 'websocket', 'sec-websocket-version': '13', 'connection': 'Upgrade', 'sec-websocket-key': 'MT3WFHu/e7Bq3sU7OJDL6A=='}
[2016-03-26 15:32:53,463] [DEBUG] mod_pywebsocket.handshake: Trying protocol version RFC 6455
[2016-03-26 15:32:53,464] [DEBUG] mod_pywebsocket.handshake.hybi.Handshaker: Client request does not have origin header
[2016-03-26 15:32:53,464] [DEBUG] mod_pywebsocket.handshake.hybi.Handshaker: Sec-WebSocket-Key: 'MT3WFHu/e7Bq3sU7OJDL6A==' (31 3d d6 14 7b bf 7b b0 6a de c5 3b 38 90 cb e8)
[2016-03-26 15:32:53,464] [DEBUG] mod_pywebsocket.handshake.hybi.Handshaker: Sec-WebSocket-Accept: '3sTQX1KZIJ/KxgemX6eZegWHJhY=' (de c4 d0 5f 52 99 20 9f ca c6 07 a6 5f a7 99 7a 05 87 26 16)
[2016-03-26 15:32:53,465] [DEBUG] mod_pywebsocket.handshake.hybi.Handshaker: Protocol version is RFC 6455
[2016-03-26 15:32:53,465] [DEBUG] mod_pywebsocket.handshake.hybi.Handshaker: Sent server's opening handshake: 'HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: 3sTQX1KZIJ/KxgemX6eZegWHJhY=\r\n\r\n'
[2016-03-26 15:32:53,465] [INFO] mod_pywebsocket.handshake: Established (RFC 6455 protocol)
[2016-03-26 15:32:53,466] [DEBUG] mod_pywebsocket._stream_hybi.Stream: Initiated closing handshake (code=1000, reason='')
```

Any suggestions, let me know. Feel free to continue the discussion in another issue after merging the PR if you like, or we can just keep the chat here for simplicity.
